### PR TITLE
Embedding dependency fixes

### DIFF
--- a/embedding/Dockerfile
+++ b/embedding/Dockerfile
@@ -18,9 +18,6 @@ RUN make -C src/resources/models
 RUN mkdir -p /usr/lib/nltk_data \
  && python -m nltk.downloader -d /usr/lib/nltk_data stopwords wordnet punkt
 
-# we need to upgrade numpy again for it to be detected by pytorch later
-RUN pip install --no-cache-dir numpy==1.24.1
-
 COPY ./embedding/src/ src/
 COPY ./text_preprocessing src/text_preprocessing
 

--- a/embedding/requirements.txt
+++ b/embedding/requirements.txt
@@ -3,7 +3,7 @@
 # actual dependencies,
 # update here
 allennlp==0.8.0 # needs to be 0.9.0 because after that, Elmo is dropped from the library
-fastapi==0.90.0
+fastapi==0.95.2
 joblib==1.2.0
 nltk==3.8.1
 numpy==1.20 # needs to be 1.20 because after that, np.int does not exist any more, which breaks nltk

--- a/embedding/requirements.txt
+++ b/embedding/requirements.txt
@@ -37,7 +37,7 @@ docutils==0.19
 editdistance==0.6.2
 exceptiongroup==1.1.0
 flaky==3.7.0
-Flask==2.2.2
+Flask==2.2.5
 Flask-Cors==3.0.10
 fonttools==4.38.0
 ftfy==6.1.1


### PR DESCRIPTION
When testing #64, I noticed new package version problems which I hadn't discovered before because I wasn't using the docker images actively myself.
Specifically, the issues were:
- `AttributeError: 'FastAPI' object has no attribute 'debug'` when starting the embedding service => updated fastapi to fix it
- `numpy.int` not found error in embedding service => removed explicit upgrade step from Dockerfile