### PR TITLE
Add old-version numpy fixes

### DIFF
--- a/embedding/Dockerfile
+++ b/embedding/Dockerfile
@@ -18,6 +18,9 @@ RUN make -C src/resources/models
 RUN mkdir -p /usr/lib/nltk_data \
  && python -m nltk.downloader -d /usr/lib/nltk_data stopwords wordnet punkt
 
+# we need to upgrade numpy again for it to be detected by pytorch later
+RUN pip install --no-cache-dir numpy==1.24.1
+
 COPY ./embedding/src/ src/
 COPY ./text_preprocessing src/text_preprocessing
 

--- a/text_preprocessing/data_cleaner.py
+++ b/text_preprocessing/data_cleaner.py
@@ -1,5 +1,11 @@
 import re
 
+# needed for compatibility with sklearn, which assumes an old numpy version
+import numpy as np
+np.int = int
+np.bool = bool
+np.float = float
+
 from nltk.corpus import stopwords
 from nltk.stem.wordnet import WordNetLemmatizer
 


### PR DESCRIPTION
While creating instructions on how to run CoFee with Docker, I tried re-building it with Docker. Apparently, #65 broke the setup because of numpy version conflicts - I believe I had not noticed this because Docker was caching my images.

This PR fixes this.